### PR TITLE
fix: remplacer tous les termes yourorg par aboigues

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,7 +74,7 @@ changelog:
 
 release:
   github:
-    owner: yourorg
+    owner: aboigues
     name: k8t
   draft: false
   prerelease: auto
@@ -83,10 +83,10 @@ release:
 brews:
   - name: k8t
     repository:
-      owner: yourorg
+      owner: aboigues
       name: homebrew-tap
     directory: Formula
-    homepage: https://github.com/yourorg/k8t
+    homepage: https://github.com/aboigues/k8t
     description: Kubernetes administration toolkit for diagnosing common issues
     license: Apache-2.0
     dependencies:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Identifies root causes of ImagePullBackOff errors in pods by analyzing:
 ### From Source
 
 ```bash
-git clone https://github.com/yourorg/k8t.git
+git clone https://github.com/aboigues/k8t.git
 cd k8t
 make build
 sudo cp bin/k8t /usr/local/bin/
@@ -32,7 +32,7 @@ sudo cp bin/k8t /usr/local/bin/
 ### Using Go Install
 
 ```bash
-go install github.com/yourorg/k8t/cmd/k8t@latest
+go install github.com/aboigues/k8t/cmd/k8t@latest
 ```
 
 ## Quick Start

--- a/specs/001-imagepullbackoff-analyzer/quickstart.md
+++ b/specs/001-imagepullbackoff-analyzer/quickstart.md
@@ -49,14 +49,14 @@ kubectl auth can-i list events
 ### 1. Clone Repository
 
 ```bash
-git clone https://github.com/yourorg/k8t.git
+git clone https://github.com/aboigues/k8t.git
 cd k8t
 ```
 
 ### 2. Initialize Go Module
 
 ```bash
-go mod init github.com/yourorg/k8t
+go mod init github.com/aboigues/k8t
 go mod tidy
 ```
 
@@ -270,7 +270,7 @@ package unit
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
-	"github.com/yourorg/k8t/pkg/analyzer"
+	"github.com/aboigues/k8t/pkg/analyzer"
 )
 
 func TestParseImagePullEvent(t *testing.T) {
@@ -301,8 +301,8 @@ import (
 	"context"
 	"testing"
 	"github.com/stretchr/testify/require"
-	"github.com/yourorg/k8t/pkg/analyzer"
-	"github.com/yourorg/k8t/pkg/k8s"
+	"github.com/aboigues/k8t/pkg/analyzer"
+	"github.com/aboigues/k8t/pkg/k8s"
 )
 
 func TestAnalyzePodWithImageNotFound(t *testing.T) {

--- a/specs/001-imagepullbackoff-analyzer/research.md
+++ b/specs/001-imagepullbackoff-analyzer/research.md
@@ -242,7 +242,7 @@ github.com/spf13/viper    // Configuration
 
 **Dependency Management**: Go modules (built-in since Go 1.11)
 ```bash
-go mod init github.com/yourorg/k8t
+go mod init github.com/aboigues/k8t
 go mod tidy
 ```
 
@@ -336,7 +336,7 @@ k8t/
 
 ### Core Dependencies (go.mod):
 ```go
-module github.com/yourorg/k8t
+module github.com/aboigues/k8t
 
 go 1.21
 

--- a/specs/001-imagepullbackoff-analyzer/tasks.md
+++ b/specs/001-imagepullbackoff-analyzer/tasks.md
@@ -25,7 +25,7 @@
 
 **Purpose**: Project initialization and basic structure
 
-- [ ] T001 Initialize Go module with github.com/yourorg/k8t
+- [ ] T001 Initialize Go module with github.com/aboigues/k8t
 - [ ] T002 Create directory structure per plan.md (cmd/k8t, pkg/{analyzer,k8s,output,types}, tests/{unit,integration,contract})
 - [ ] T003 [P] Install core dependencies: client-go v0.29+, cobra v1.8+, yaml.v3, color, zap
 - [ ] T004 [P] Create Makefile with targets: build, test, test-unit, test-integration, lint, security, fmt


### PR DESCRIPTION
## Résumé
Correction de tous les reliquats avec "yourorg" dans le codebase en les remplaçant par "aboigues".

## Fichiers modifiés
- ✅ README.md (URLs GitHub)
- ✅ .goreleaser.yml (owner GitHub et homepage)
- ✅ specs/001-imagepullbackoff-analyzer/tasks.md (chemin du module Go)
- ✅ specs/001-imagepullbackoff-analyzer/research.md (chemins du module Go)
- ✅ specs/001-imagepullbackoff-analyzer/quickstart.md (URLs GitHub et chemins d'import)

## Changements
- GitHub URLs: `github.com/yourorg/k8t` → `github.com/aboigues/k8t`
- Go module: `github.com/yourorg/k8t` → `github.com/aboigues/k8t`
- Owner GitHub: `yourorg` → `aboigues`

Résout #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)