### PR TITLE
fix: improve k8t check output and error handling

### DIFF
--- a/cmd/k8t/main.go
+++ b/cmd/k8t/main.go
@@ -277,6 +277,10 @@ func runCheckAnalysis(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Found %d pod(s) in namespace %s\n", len(pods), ns)
+		}
+
 		nsIssues := 0
 		for _, pod := range pods {
 			// Check pod status for common issues
@@ -312,7 +316,7 @@ func runCheckAnalysis(cmd *cobra.Command, args []string) error {
 
 	// Exit with appropriate code
 	if totalIssues > 0 {
-		os.Exit(1)
+		return fmt.Errorf("found %d issue(s) in cluster", totalIssues)
 	}
 
 	return nil

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -135,7 +135,10 @@ func (c *Client) ListPodsInNamespace(ctx context.Context, namespace string) ([]P
 			Status:    pod.Status,
 		}
 
-		// Extract container statuses
+		// Extract container statuses (including init containers)
+		for _, cs := range pod.Status.InitContainerStatuses {
+			podInfo.ContainerStatuses = append(podInfo.ContainerStatuses, cs)
+		}
 		for _, cs := range pod.Status.ContainerStatuses {
 			podInfo.ContainerStatuses = append(podInfo.ContainerStatuses, cs)
 		}


### PR DESCRIPTION
## Summary
Fixes the issues reported in #18 where `k8t check` would return exit code 1 but display no output.

## Root Causes Identified

1. **Output buffering issue**: The code was calling `os.Exit(1)` directly, which could terminate the program before stdout was properly flushed
2. **Missing init container checks**: Only regular containers were being checked for issues, init containers were ignored
3. **Lack of debugging info**: No verbose output to help diagnose what the command was doing

## Changes Made

### 1. Fixed Exit Code Handling
- **Before**: Used `os.Exit(1)` directly when issues were found
- **After**: Return a proper error and let Cobra handle the exit code
- **Benefit**: Ensures stdout is flushed and output is displayed before program termination

### 2. Added Init Container Support  
- **Location**: `pkg/k8s/client.go` in `ListPodsInNamespace()`
- **Change**: Now includes both `InitContainerStatuses` and `ContainerStatuses` when building PodInfo
- **Benefit**: Catches ImagePullBackOff and other issues in init containers

### 3. Enhanced Verbose Logging
- Added logging to show:
  - Which namespace is being checked
  - How many pods were found in each namespace
- **Benefit**: Helps users debug why the command might not find issues

## Testing

- [x] Code compiles successfully
- [x] All existing tests pass
- [x] Verified error return instead of os.Exit()
- [x] Confirmed init containers are now included
- [x] Verified check command appears in help output

## Note on k8t help

The issue mentions that `k8t help` doesn't show the `check` command. Testing locally shows that it does appear in the help output, so this may have been due to the user running an outdated binary before the command was merged.

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)