### PR TITLE
fix: correct command syntax in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ go install github.com/aboigues/k8t/cmd/k8t@latest
 
 ```bash
 # Basic analysis
-k8t analyze imagepullbackoff pod my-pod -n my-namespace
+k8t analyze imagepullbackoff my-pod -n my-namespace
 
 # Detailed analysis with network diagnostics
-k8t analyze imagepullbackoff pod my-pod -n my-namespace --detailed
+k8t analyze imagepullbackoff my-pod -n my-namespace --detailed
 
 # JSON output for automation
-k8t analyze imagepullbackoff pod my-pod -o json
+k8t analyze imagepullbackoff my-pod -o json
 ```
 
 ### Analyze Multiple Pods
@@ -92,7 +92,7 @@ Human-readable colored output with remediation steps.
 Machine-readable format for automation and integration:
 
 ```bash
-k8t analyze imagepullbackoff pod my-pod -o json
+k8t analyze imagepullbackoff my-pod -o json
 ```
 
 ### YAML
@@ -100,7 +100,7 @@ k8t analyze imagepullbackoff pod my-pod -o json
 YAML format for Kubernetes-native workflows:
 
 ```bash
-k8t analyze imagepullbackoff pod my-pod -o yaml
+k8t analyze imagepullbackoff my-pod -o yaml
 ```
 
 ## Root Causes Detected

--- a/specs/001-imagepullbackoff-analyzer/contracts/cli-interface.md
+++ b/specs/001-imagepullbackoff-analyzer/contracts/cli-interface.md
@@ -30,22 +30,22 @@ k8t analyze image-pull [TARGET] [flags] # Alternative
 
 **Syntax**:
 ```bash
-k8t analyze imagepullbackoff pod <POD_NAME> [flags]
+k8t analyze imagepullbackoff <POD_NAME> [flags]
 ```
 
 **Example Usage**:
 ```bash
 # Analyze single pod in default namespace
-k8t analyze imagepullbackoff pod my-app-pod
+k8t analyze imagepullbackoff my-app-pod
 
 # Analyze pod in specific namespace
-k8t analyze imagepullbackoff pod my-app-pod -n production
+k8t analyze imagepullbackoff my-app-pod -n production
 
 # JSON output for automation
-k8t analyze imagepullbackoff pod my-app-pod -o json
+k8t analyze imagepullbackoff my-app-pod -o json
 
 # YAML output
-k8t analyze imagepullbackoff pod my-app-pod -o yaml
+k8t analyze imagepullbackoff my-app-pod -o yaml
 ```
 
 **Flags**:
@@ -185,7 +185,7 @@ Analysis completed in 1.2s
 
 **Syntax**:
 ```bash
-k8t analyze imagepullbackoff pod <POD_NAME> --detailed [flags]
+k8t analyze imagepullbackoff <POD_NAME> --detailed [flags]
 ```
 
 **New Flags**:
@@ -375,7 +375,7 @@ Applicable to all commands:
 ### Permission Errors (RR-001)
 
 ```bash
-$ k8t analyze imagepullbackoff pod my-pod -n production
+$ k8t analyze imagepullbackoff my-pod -n production
 
 ERROR: Insufficient RBAC permissions
 
@@ -407,7 +407,7 @@ Exit code: 2
 ### Pod Not Found
 
 ```bash
-$ k8t analyze imagepullbackoff pod nonexistent -n production
+$ k8t analyze imagepullbackoff nonexistent -n production
 
 ERROR: Pod not found
 
@@ -424,7 +424,7 @@ Exit code: 3
 ### API Timeout (RR-002)
 
 ```bash
-$ k8t analyze imagepullbackoff pod my-pod
+$ k8t analyze imagepullbackoff my-pod
 
 ERROR: Kubernetes API timeout
 
@@ -462,7 +462,7 @@ Exit code: 4
 ### Scenario 1: Image Not Found
 
 ```bash
-$ k8t analyze imagepullbackoff pod broken-app
+$ k8t analyze imagepullbackoff broken-app
 
 ImagePullBackOff Analysis: broken-app (namespace: default)
 ================================================================================
@@ -486,7 +486,7 @@ Exit code: 0
 ### Scenario 2: Authentication Failure
 
 ```bash
-$ k8t analyze imagepullbackoff pod private-app --detailed
+$ k8t analyze imagepullbackoff private-app --detailed
 
 ImagePullBackOff Analysis: private-app (namespace: default) [DETAILED]
 ================================================================================
@@ -517,7 +517,7 @@ Exit code: 0
 ### Scenario 3: Network Issue with Diagnostics
 
 ```bash
-$ k8t analyze imagepullbackoff pod network-test -d
+$ k8t analyze imagepullbackoff network-test -d
 
 ImagePullBackOff Analysis: network-test (namespace: default) [DETAILED]
 ================================================================================
@@ -578,7 +578,7 @@ $ k8t analyze imagepullbackoff deployment web-app -n production -o json | jq '.s
 When `--verbose` flag is used, audit logs are written to stderr:
 
 ```bash
-$ k8t analyze imagepullbackoff pod my-pod --verbose
+$ k8t analyze imagepullbackoff my-pod --verbose
 
 [stderr output:]
 AUDIT: 2025-12-18T10:21:00Z GET pods/my-pod namespace=default
@@ -637,22 +637,22 @@ Not in current scope but documented for reference:
 
 1. **kubectl Plugin Integration**:
    ```bash
-   kubectl analyze imagepullbackoff pod my-pod
+   kubectl analyze imagepullbackoff my-pod
    ```
 
 2. **Watch Mode** (real-time monitoring):
    ```bash
-   k8t analyze imagepullbackoff pod my-pod --watch
+   k8t analyze imagepullbackoff my-pod --watch
    ```
 
 3. **Historical Analysis** (requires persistence):
    ```bash
-   k8t analyze imagepullbackoff pod my-pod --since 1h
+   k8t analyze imagepullbackoff my-pod --since 1h
    ```
 
 4. **Auto-Remediation** (requires write permissions):
    ```bash
-   k8t analyze imagepullbackoff pod my-pod --fix
+   k8t analyze imagepullbackoff my-pod --fix
    ```
 
 5. **Export to File**:

--- a/specs/001-imagepullbackoff-analyzer/quickstart.md
+++ b/specs/001-imagepullbackoff-analyzer/quickstart.md
@@ -226,7 +226,7 @@ k8t/
 
    # Build and test
    go build -o k8t ./cmd/k8t
-   ./k8t analyze imagepullbackoff pod test-pod
+   ./k8t analyze imagepullbackoff test-pod
    ```
 
 ### Quick Commands
@@ -486,7 +486,7 @@ mocks:
 export K8T_LOG_LEVEL=debug
 
 # Run with verbose flag
-./k8t analyze imagepullbackoff pod my-pod --verbose
+./k8t analyze imagepullbackoff my-pod --verbose
 ```
 
 ### Debug K8s API Calls
@@ -500,7 +500,7 @@ export KUBERNETES_SERVICE_HOST=localhost
 export KUBERNETES_SERVICE_PORT=8080
 
 # Run analyzer (API calls visible in proxy logs)
-./k8t analyze imagepullbackoff pod my-pod
+./k8t analyze imagepullbackoff my-pod
 ```
 
 ### Test with Sample Pods
@@ -513,7 +513,7 @@ kubectl run test-not-found --image=nonexistent:v999
 kubectl wait --for=condition=Ready=false pod/test-not-found --timeout=60s
 
 # Run analyzer
-./k8t analyze imagepullbackoff pod test-not-found
+./k8t analyze imagepullbackoff test-not-found
 
 # Cleanup
 kubectl delete pod test-not-found
@@ -652,7 +652,7 @@ if cpuprofile := os.Getenv("CPUPROFILE"); cpuprofile != "" {
 
 ```bash
 # Run with profiling
-CPUPROFILE=cpu.prof ./k8t analyze imagepullbackoff pod my-pod
+CPUPROFILE=cpu.prof ./k8t analyze imagepullbackoff my-pod
 
 # Analyze profile
 go tool pprof cpu.prof

--- a/specs/001-imagepullbackoff-analyzer/tasks.md
+++ b/specs/001-imagepullbackoff-analyzer/tasks.md
@@ -60,7 +60,7 @@
 
 **Goal**: Single pod analysis with root cause identification and remediation steps
 
-**Independent Test**: Create pod with invalid image, run `k8t analyze imagepullbackoff pod <name>`, verify root cause identified correctly with remediation steps
+**Independent Test**: Create pod with invalid image, run `k8t analyze imagepullbackoff <name>`, verify root cause identified correctly with remediation steps
 
 ### Implementation for User Story 1
 
@@ -261,7 +261,7 @@ Task T039 [P] [US1]: Create test manifests
 2. Complete Phase 2: Foundational (T008-T017) - CRITICAL - blocks all stories
 3. Complete Phase 3: User Story 1 (T018-T042)
 4. **STOP and VALIDATE**: Test User Story 1 independently
-   - `k8t analyze imagepullbackoff pod test-pod`
+   - `k8t analyze imagepullbackoff test-pod`
    - Verify root cause identification works
    - Verify all output formats (text/JSON/YAML)
    - Verify RBAC permissions minimal


### PR DESCRIPTION
## Summary
Fixes #20 - Corrects incorrect command syntax shown in documentation.

## Problem

The documentation showed an incorrect command syntax with an extra "pod" keyword:
```bash
k8t analyze imagepullbackoff pod my-pod
```

However, the actual CLI implementation expects:
```bash
k8t analyze imagepullbackoff my-pod
```

The word "pod" should not be included as it's not part of the command structure.

## Changes Made

Updated command syntax in the following files:

1. **README.md**
   - Quick Start section examples
   - Output Formats section examples

2. **specs/001-imagepullbackoff-analyzer/contracts/cli-interface.md**
   - Command syntax definitions
   - All example usages

3. **specs/001-imagepullbackoff-analyzer/quickstart.md**
   - Usage examples

4. **specs/001-imagepullbackoff-analyzer/tasks.md**
   - Task descriptions

All occurrences of `k8t analyze imagepullbackoff pod <name>` have been replaced with `k8t analyze imagepullbackoff <name>` to match the actual CLI implementation.

## Testing

- [x] Code compiles successfully
- [x] All existing tests pass
- [x] Verified documentation now matches actual command usage
- [x] Confirmed help output shows correct syntax: `k8t analyze imagepullbackoff <pod-name> [flags]`

## Impact

This is a documentation-only change. No code changes were made. Users following the documentation will now see the correct command syntax that matches the actual CLI behavior.

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)