### PR TITLE
feat: add analyze all command with aa alias

### DIFF
--- a/cmd/k8t/main.go
+++ b/cmd/k8t/main.go
@@ -493,7 +493,7 @@ func runAnalyzeAllAnalysis(cmd *cobra.Command, args []string) error {
 				continue
 			}
 			if format == output.FormatTypeText {
-				fmt.Println("\n" + "---" + "\n")
+				fmt.Println("\n---")
 			}
 		}
 
@@ -646,7 +646,7 @@ func runAAAnalysis(cmd *cobra.Command, args []string) error {
 				continue
 			}
 			if format == output.FormatTypeText {
-				fmt.Println("\n" + "---" + "\n")
+				fmt.Println("\n---")
 			}
 		}
 


### PR DESCRIPTION
## Summary

Implements issue #23 - Global command to analyze all Kubernetes server problems.

## Changes

### New Commands
- **`k8t analyze all`**: Scans the Kubernetes cluster for pods with ImagePullBackOff errors and performs detailed root cause analysis on each affected pod
- **`k8t aa`**: Shorthand alias for quick access to `analyze all`

### Features
- **Namespace Support**: 
  - Single namespace analysis with `-n/--namespace` flag
  - All namespaces analysis with `-A/--all-namespaces` flag
- **Output Formats**: Support for text, JSON, and YAML output formats
- **Timeout Configuration**: Per-pod analysis timeout (default: 30s)
- **Aggregated Results**: Displays individual pod analyses followed by a comprehensive summary
- **Robust Error Handling**: Continues analysis even if individual pods fail

### Implementation Details
- Reuses existing analyzer infrastructure for consistent root cause detection
- Leverages the same event parsing and remediation step generation as single-pod analysis
- Provides both detailed reports and high-level summary for cluster-wide visibility

## Usage Examples

```bash
# Analyze all pods in the default namespace
k8t analyze all

# Analyze all pods across all namespaces
k8t analyze all -A

# Use the shorthand alias
k8t aa -A

# Output in JSON format
k8t analyze all -o json

# Analyze specific namespace with verbose output
k8t analyze all -n production --verbose
```

## Test Plan
- [x] Build succeeds without errors
- [x] Help text displays correctly for both commands
- [x] Commands are properly registered in CLI
- [x] Both `k8t analyze all` and `k8t aa` work identically
- [x] All flags are properly recognized

## Related Issues

Closes #23

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)