### PR TITLE
feat: add kubectl plugin integration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,8 +25,29 @@ builds:
       - -X main.date={{.Date}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 
+  - id: kubectl-k8t
+    main: ./cmd/k8t
+    binary: kubectl-k8t
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
 archives:
   - id: k8t
+    builds:
+      - k8t
     format: tar.gz
     name_template: >-
       {{ .ProjectName }}_
@@ -39,6 +60,21 @@ archives:
         format: zip
     files:
       - README.md
+      - LICENSE
+
+  - id: kubectl-k8t
+    builds:
+      - kubectl-k8t
+    format: tar.gz
+    name_template: >-
+      kubectl-{{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
       - LICENSE
 
 checksum:

--- a/KREW.md
+++ b/KREW.md
@@ -1,0 +1,160 @@
+# Krew Plugin Distribution Guide
+
+This guide explains how to distribute k8t via the krew plugin manager.
+
+## Prerequisites
+
+- A GitHub release with kubectl-k8t binaries for all platforms
+- Access to fork and submit PRs to [krew-index](https://github.com/kubernetes-sigs/krew-index)
+
+## Publishing to Krew
+
+### 1. Create a Release
+
+First, create a new release with goreleaser:
+
+```bash
+# Tag the release
+git tag -a v0.1.0 -m "Release v0.1.0"
+git push origin v0.1.0
+
+# Build and publish release
+goreleaser release --clean
+```
+
+This will create GitHub releases with binaries for all platforms.
+
+### 2. Update the Krew Manifest
+
+After the release is published, update `k8t.yaml` with:
+
+1. The correct version number
+2. SHA256 checksums for each platform
+
+To generate SHA256 checksums:
+
+```bash
+# Download each release artifact and compute SHA256
+curl -sL https://github.com/aboigues/k8t/releases/download/v0.1.0/kubectl-k8t_v0.1.0_linux_amd64.tar.gz | sha256sum
+curl -sL https://github.com/aboigues/k8t/releases/download/v0.1.0/kubectl-k8t_v0.1.0_linux_arm64.tar.gz | sha256sum
+curl -sL https://github.com/aboigues/k8t/releases/download/v0.1.0/kubectl-k8t_v0.1.0_darwin_amd64.tar.gz | sha256sum
+curl -sL https://github.com/aboigues/k8t/releases/download/v0.1.0/kubectl-k8t_v0.1.0_darwin_arm64.tar.gz | sha256sum
+curl -sL https://github.com/aboigues/k8t/releases/download/v0.1.0/kubectl-k8t_v0.1.0_windows_amd64.zip | sha256sum
+```
+
+Update each `sha256` field in `k8t.yaml` with the computed values.
+
+### 3. Test the Plugin Locally
+
+Before submitting to krew-index, test the plugin manifest locally:
+
+```bash
+# Validate the manifest
+kubectl krew install --manifest=k8t.yaml
+
+# Test the plugin
+kubectl k8t version
+kubectl k8t analyze imagepullbackoff --help
+
+# Uninstall for cleanup
+kubectl krew uninstall k8t
+```
+
+### 4. Submit to Krew Index
+
+Once tested, submit the plugin to the official krew-index:
+
+```bash
+# Fork the krew-index repository
+# https://github.com/kubernetes-sigs/krew-index
+
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/krew-index.git
+cd krew-index
+
+# Create a new branch
+git checkout -b add-k8t-plugin
+
+# Copy the plugin manifest
+cp /path/to/k8t/k8t.yaml plugins/k8t.yaml
+
+# Commit and push
+git add plugins/k8t.yaml
+git commit -m "Add k8t plugin"
+git push origin add-k8t-plugin
+
+# Create a pull request
+# Go to https://github.com/kubernetes-sigs/krew-index and create a PR
+```
+
+### 5. Maintain the Plugin
+
+For subsequent releases:
+
+1. Create a new release with goreleaser
+2. Update the plugin manifest with new version and checksums
+3. Submit a PR to krew-index with the updated manifest
+
+```bash
+cd krew-index
+git checkout -b update-k8t-v0.2.0
+cp /path/to/k8t/k8t.yaml plugins/k8t.yaml
+git add plugins/k8t.yaml
+git commit -m "Update k8t plugin to v0.2.0"
+git push origin update-k8t-v0.2.0
+```
+
+## Automated Updates
+
+Consider using [krew-release-bot](https://github.com/rajatjindal/krew-release-bot) to automate plugin updates:
+
+1. Add a `.krew.yaml` template to your repository
+2. Configure GitHub Actions to use krew-release-bot
+3. Bot automatically creates PRs to krew-index on new releases
+
+Example GitHub Action:
+
+```yaml
+name: Release to Krew
+on:
+  release:
+    types: [published]
+
+jobs:
+  krew:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rajatjindal/krew-release-bot@v0.0.46
+        with:
+          krew_template_file: k8t.yaml
+```
+
+## Troubleshooting
+
+### Plugin not found after installation
+
+```bash
+# Ensure krew is properly configured
+kubectl krew version
+
+# Update krew index
+kubectl krew update
+
+# Try installing again
+kubectl krew install k8t
+```
+
+### SHA256 mismatch
+
+If users report SHA256 mismatches:
+
+1. Verify the release artifacts haven't been modified
+2. Regenerate checksums from the published release artifacts
+3. Update the manifest and submit a fix PR to krew-index
+
+## Resources
+
+- [Krew Plugin Developer Guide](https://krew.sigs.k8s.io/docs/developer-guide/)
+- [kubectl Plugin Documentation](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/)
+- [krew-index Repository](https://github.com/kubernetes-sigs/krew-index)
+- [krew-release-bot](https://github.com/rajatjindal/krew-release-bot)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: build test test-unit test-integration lint security fmt clean help
+.PHONY: build build-plugin test test-unit test-integration lint security fmt clean help install-plugin
 
 BINARY_NAME=k8t
+PLUGIN_NAME=kubectl-k8t
 GO=go
 GOFLAGS=-v
 
@@ -20,8 +21,17 @@ help: ## Display this help message
 build: ## Build the k8t binary
 	$(GO) build $(GOFLAGS) $(LDFLAGS) -o bin/$(BINARY_NAME) ./cmd/k8t
 
+build-plugin: ## Build the kubectl-k8t plugin binary
+	$(GO) build $(GOFLAGS) $(LDFLAGS) -o bin/$(PLUGIN_NAME) ./cmd/k8t
+
 install: ## Install k8t to $GOPATH/bin
 	$(GO) install $(GOFLAGS) $(LDFLAGS) ./cmd/k8t
+
+install-plugin: build-plugin ## Install kubectl-k8t plugin to /usr/local/bin
+	@echo "Installing kubectl-k8t plugin to /usr/local/bin"
+	@sudo cp bin/$(PLUGIN_NAME) /usr/local/bin/$(PLUGIN_NAME)
+	@sudo chmod +x /usr/local/bin/$(PLUGIN_NAME)
+	@echo "Plugin installed successfully. Use 'kubectl k8t' to run."
 
 test: test-unit test-integration ## Run all tests
 
@@ -73,4 +83,4 @@ release: ## Build release binaries (requires goreleaser)
 
 ci: fmt vet lint security test ## Run all CI checks
 
-all: clean fmt vet lint test build ## Clean, format, lint, test, and build
+all: clean fmt vet lint test build build-plugin ## Clean, format, lint, test, and build both binaries

--- a/README.md
+++ b/README.md
@@ -20,7 +20,25 @@ Identifies root causes of ImagePullBackOff errors in pods by analyzing:
 
 ## Installation
 
-### From Source
+### As a kubectl Plugin (Recommended)
+
+Install k8t as a kubectl plugin using krew:
+
+```bash
+kubectl krew install k8t
+```
+
+Or manually install the plugin:
+
+```bash
+git clone https://github.com/aboigues/k8t.git
+cd k8t
+make install-plugin
+```
+
+### Standalone Binary
+
+#### From Source
 
 ```bash
 git clone https://github.com/aboigues/k8t.git
@@ -29,7 +47,7 @@ make build
 sudo cp bin/k8t /usr/local/bin/
 ```
 
-### Using Go Install
+#### Using Go Install
 
 ```bash
 go install github.com/aboigues/k8t/cmd/k8t@latest
@@ -37,30 +55,35 @@ go install github.com/aboigues/k8t/cmd/k8t@latest
 
 ## Quick Start
 
+k8t can be used as a kubectl plugin or as a standalone binary. Both provide identical functionality.
+
 ### Analyze a Single Pod
 
 ```bash
-# Basic analysis
+# As kubectl plugin
+kubectl k8t analyze imagepullbackoff my-pod -n my-namespace
+
+# Or as standalone binary
 k8t analyze imagepullbackoff my-pod -n my-namespace
 
-# Detailed analysis with network diagnostics
-k8t analyze imagepullbackoff my-pod -n my-namespace --detailed
-
 # JSON output for automation
-k8t analyze imagepullbackoff my-pod -o json
+kubectl k8t analyze imagepullbackoff my-pod -o json
 ```
 
 ### Analyze Multiple Pods
 
 ```bash
 # Analyze all pods in a namespace
-k8t analyze imagepullbackoff namespace my-namespace
+kubectl k8t analyze imagepullbackoff namespace my-namespace
 
 # Analyze a deployment
-k8t analyze imagepullbackoff deployment my-deployment -n my-namespace
+kubectl k8t analyze imagepullbackoff deployment my-deployment -n my-namespace
 
 # Show only pods with issues
-k8t analyze imagepullbackoff namespace my-namespace --issues-only
+kubectl k8t analyze imagepullbackoff namespace my-namespace --issues-only
+
+# Shorthand: analyze all pods with issues
+kubectl k8t aa -A
 ```
 
 ## RBAC Requirements
@@ -92,7 +115,7 @@ Human-readable colored output with remediation steps.
 Machine-readable format for automation and integration:
 
 ```bash
-k8t analyze imagepullbackoff my-pod -o json
+kubectl k8t analyze imagepullbackoff my-pod -o json
 ```
 
 ### YAML
@@ -100,7 +123,7 @@ k8t analyze imagepullbackoff my-pod -o json
 YAML format for Kubernetes-native workflows:
 
 ```bash
-k8t analyze imagepullbackoff my-pod -o yaml
+kubectl k8t analyze imagepullbackoff my-pod -o yaml
 ```
 
 ## Root Causes Detected
@@ -173,6 +196,46 @@ k8t/
     ├── integration/      # Integration tests (kind)
     └── contract/         # API contract tests
 ```
+
+## kubectl Plugin Integration
+
+k8t is available as a kubectl plugin, providing seamless integration with your existing kubectl workflows.
+
+### How it Works
+
+When installed as a kubectl plugin, the binary is named `kubectl-k8t`. kubectl automatically discovers and executes plugins from your PATH when you run `kubectl k8t`.
+
+### Installation via Krew
+
+[Krew](https://krew.sigs.k8s.io/) is the recommended plugin manager for kubectl:
+
+```bash
+# Install krew (if not already installed)
+# See: https://krew.sigs.k8s.io/docs/user-guide/setup/install/
+
+# Install k8t plugin
+kubectl krew install k8t
+
+# Use the plugin
+kubectl k8t analyze imagepullbackoff my-pod -n my-namespace
+```
+
+### Manual Plugin Installation
+
+```bash
+# Build the plugin binary
+make build-plugin
+
+# Install to PATH
+make install-plugin
+
+# Verify installation
+kubectl plugin list | grep k8t
+```
+
+### Compatibility
+
+The kubectl plugin is fully compatible with the standalone binary. All commands, flags, and features work identically in both modes.
 
 ## Contributing
 

--- a/k8t.yaml
+++ b/k8t.yaml
@@ -1,0 +1,83 @@
+apiVersion: krew.googlecontainertools.dev/v1alpha2
+kind: Plugin
+metadata:
+  name: k8t
+spec:
+  version: "v0.1.0"
+  homepage: https://github.com/aboigues/k8t
+  shortDescription: Kubernetes Administration Toolkit for diagnosing pod issues
+  description: |
+    k8t is a diagnostic CLI tool for identifying root causes of ImagePullBackOff
+    errors in Kubernetes pods. It analyzes pod events, image pull secrets,
+    registry connectivity, and provides actionable remediation steps.
+
+    Features:
+    - Single pod analysis with detailed diagnostics
+    - Multi-pod analysis for workloads and namespaces
+    - Network testing (DNS, TCP, HTTP)
+    - Multiple output formats (text, JSON, YAML)
+    - Root cause detection for common image pull issues
+  caveats: |
+    Requires RBAC permissions to read pods and events in the target namespace.
+    See documentation for required Role/RoleBinding configuration.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/aboigues/k8t/releases/download/{{ .TagName }}/kubectl-k8t_{{ .TagName }}_linux_amd64.tar.gz
+    sha256: "PLACEHOLDER_LINUX_AMD64_SHA256"
+    bin: kubectl-k8t
+    files:
+    - from: kubectl-k8t
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/aboigues/k8t/releases/download/{{ .TagName }}/kubectl-k8t_{{ .TagName }}_linux_arm64.tar.gz
+    sha256: "PLACEHOLDER_LINUX_ARM64_SHA256"
+    bin: kubectl-k8t
+    files:
+    - from: kubectl-k8t
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/aboigues/k8t/releases/download/{{ .TagName }}/kubectl-k8t_{{ .TagName }}_darwin_amd64.tar.gz
+    sha256: "PLACEHOLDER_DARWIN_AMD64_SHA256"
+    bin: kubectl-k8t
+    files:
+    - from: kubectl-k8t
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/aboigues/k8t/releases/download/{{ .TagName }}/kubectl-k8t_{{ .TagName }}_darwin_arm64.tar.gz
+    sha256: "PLACEHOLDER_DARWIN_ARM64_SHA256"
+    bin: kubectl-k8t
+    files:
+    - from: kubectl-k8t
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/aboigues/k8t/releases/download/{{ .TagName }}/kubectl-k8t_{{ .TagName }}_windows_amd64.zip
+    sha256: "PLACEHOLDER_WINDOWS_AMD64_SHA256"
+    bin: kubectl-k8t.exe
+    files:
+    - from: kubectl-k8t.exe
+      to: .
+    - from: LICENSE
+      to: .


### PR DESCRIPTION
Implement kubectl plugin support to enable k8t usage as 'kubectl k8t' for seamless integration with existing kubectl workflows.

Changes:
- Add build-plugin and install-plugin targets in Makefile
- Configure kubectl-k8t binary in .goreleaser.yml for multi-platform releases
- Create k8t.yaml krew plugin manifest for distribution
- Add KREW.md with comprehensive publishing guide
- Update README.md with kubectl plugin installation and usage examples
- Document both standalone and plugin usage modes

This allows users to:
- Install via krew: kubectl krew install k8t
- Use as plugin: kubectl k8t analyze imagepullbackoff my-pod
- Or use standalone: k8t analyze imagepullbackoff my-pod

Resolves #12