### PR TITLE
fix: bump Go to 1.25.9 to fix GO-2026-4947, GO-2026-4946 and GO-2026-4870

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aboigues/k8t
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4


### PR DESCRIPTION
## Summary

- Bump Go toolchain de `1.25.8` vers `1.25.9` dans `go.mod`
- Corrige 3 vulnérabilités de la stdlib détectées par `govulncheck` :
  - **GO-2026-4947** : Unexpected work during chain building in `crypto/x509`
  - **GO-2026-4946** : Inefficient policy validation in `crypto/x509`
  - **GO-2026-4870** : Unauthenticated TLS 1.3 KeyUpdate record can cause DoS in `crypto/tls`

## Test plan

- [ ] Le job `Go Vulnerability Check` passe sans erreur
- [ ] Le job `CI` (build + tests) passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)